### PR TITLE
ROB-300 CVE weekly 2026-06-17 fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/chai2010/gettext-go v1.0.3 // indirect
-	github.com/containerd/containerd v1.7.30 // indirect
+	github.com/containerd/containerd v1.7.32 // indirect
 	github.com/containerd/errdefs v0.3.0 // indirect
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chai2010/gettext-go v1.0.3 h1:9liNh8t+u26xl5ddmWLmsOsdNLwkdRTg5AG+JnTiM80=
 github.com/chai2010/gettext-go v1.0.3/go.mod h1:y+wnP2cHYaVj19NZhYKAwEMH2CI1gNHeQQ+5AjwawxA=
-github.com/containerd/containerd v1.7.30 h1:/2vezDpLDVGGmkUXmlNPLCCNKHJ5BbC5tJB5JNzQhqE=
-github.com/containerd/containerd v1.7.30/go.mod h1:fek494vwJClULlTpExsmOyKCMUAbuVjlFsJQc4/j44M=
+github.com/containerd/containerd v1.7.32 h1:S54xuVcPxeLaYgaRABtpJ2VyVUVsy0IGf7qHBs+sbY8=
+github.com/containerd/containerd v1.7.32/go.mod h1:jdwD6s/BhV4XVJGrvtziNPVA+83n66TwptVaPKprq4E=
 github.com/containerd/errdefs v0.3.0 h1:FSZgGOeK4yuT/+DnF07/Olde/q4KBoMsaamhXxIMDp4=
 github.com/containerd/errdefs v0.3.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=


### PR DESCRIPTION
## Changes

| Change | CVE |
| --- | --- |
| `go.mod` / `go.sum` — `github.com/containerd/containerd` v1.7.30 → v1.7.32 (indirect dep, refreshed via `go get` + `go mod tidy`). | [CVE-2026-46680](https://github.com/containerd/containerd/security/advisories/GHSA-fqw6-gf59-qr4w) |

References:
- Containerd advisory: https://github.com/containerd/containerd/security/advisories/GHSA-fqw6-gf59-qr4w
- GitHub advisory: https://github.com/advisories/GHSA-fqw6-gf59-qr4w
- Dependabot alert: https://github.com/robusta-dev/kube-lineage/security/dependabot/68
- 1.7.32 release notes: https://github.com/containerd/containerd/releases/tag/v1.7.32

The advisory lists 1.7.32 as the fixed line for the 1.7.x branch. No source uses of containerd APIs are present in this repo — it is pulled in transitively via `helm.sh/helm/v3` — so the change is module-graph only.

## Test plan

- [x] `go mod tidy` — clean, no leftover requires.
- [x] `go build ./...` — full repo builds with the new module graph.
- [x] `go build -o /tmp/kube-lineage ./cmd/kube-lineage` + `kube-lineage version` / `--help` — binary runs, version + usage print as expected.
- [x] `go test ./...` — the only failure is the pre-existing `internal/graph` vet failure (`Infof format %s` arg-count mismatches on lines 591/598/605/612/619/626) that also fails on `master` at 4d563a7 prior to this change. Not introduced by this PR.

## Human in the loop

a. None — single indirect-dep bump driven by upstream advisory; no source-level callers in the repo.

b. Base-image suggestion: n/a (this is a Go module CVE, not a container image CVE).